### PR TITLE
Google Maps Offline Issue

### DIFF
--- a/eventApp/.idea/deviceManager.xml
+++ b/eventApp/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/eventApp/app/src/main/java/org/lightsys/eventApp/views/HousingView.java
+++ b/eventApp/app/src/main/java/org/lightsys/eventApp/views/HousingView.java
@@ -103,8 +103,9 @@ public class HousingView extends Fragment {
                     if (address != null) {
                         builder.setPositiveButton(R.string.map_button, new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int which) {
+                                String encodedAddress = Uri.encode(address);
                                 Intent intent = new Intent(android.content.Intent.ACTION_VIEW,
-                                        Uri.parse("google.navigation:q=" + address));
+                                        Uri.parse("https://www.google.com/maps/dir/?api=1&travelmode=driving&dir_action=navigate&destination=" + encodedAddress));
                                 try {
                                     startActivity(intent);
                                 } catch (android.content.ActivityNotFoundException ex) {


### PR DESCRIPTION
Fixed an issue where people who have the city maps downloaded in Google Maps were not getting accurate directions. When we used geo intent with address search, Google Maps failed to use online services, and defaulted to offline map geocoding. Using a URL forces Google to use online services.